### PR TITLE
[Subs 790] Add integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ cache:
   directories:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
+script: gradle externalCiTest

--- a/build.gradle
+++ b/build.gradle
@@ -44,3 +44,12 @@ dependencies {
 compileJava.dependsOn(processResources)
 
 bootRepackage.enabled = false
+
+task('externalCiTest', type: Test) {
+    useJUnit {
+        excludeCategories 'uk.ac.ebi.subs.BioSamplesDependentTest'
+    }
+    testLogging {
+        exceptionFormat = 'full'
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'uk.ac.ebi.subs'
-version '0.1.0-SNAPSHOT'
+version '0.2.0-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
@@ -33,10 +33,10 @@ configure(allprojects) {
 dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter'
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-amqp'
+    compile group: 'org.projectlombok', name: 'lombok', version: '1.16.12'
+
 
     optional "org.springframework.boot:spring-boot-configuration-processor"
-
-    compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.16.12'
 
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ bootRepackage.enabled = false
 
 task('externalCiTest', type: Test) {
     useJUnit {
-        excludeCategories 'uk.ac.ebi.subs.BioSamplesDependentTest'
+        excludeCategories 'uk.ac.ebi.subs.messagerecover.util.RabbitMQAndQDBDependentTest'
     }
     testLogging {
         exceptionFormat = 'full'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Sep 12 16:43:02 BST 2017
+#Fri Sep 29 09:37:15 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-all.zip

--- a/src/main/java/uk/ac/ebi/subs/messagerecover/queuemanager/MessageToReplay.java
+++ b/src/main/java/uk/ac/ebi/subs/messagerecover/queuemanager/MessageToReplay.java
@@ -7,13 +7,13 @@ import lombok.Data;
  * if the message was correct, but it failed because some service was down.
  */
 @Data
-public class MessagesToReplay {
+public class MessageToReplay {
 
     private String routingKey;
     private String body;
     private String bodyToReplay;
 
-    public MessagesToReplay(String routingKey, String body) {
+    public MessageToReplay(String routingKey, String body) {
         this.routingKey = routingKey;
         this.body = body;
     }

--- a/src/test/java/uk/ac/ebi/subs/messagerecover/FailedMessageRecoverApplicationTest.java
+++ b/src/test/java/uk/ac/ebi/subs/messagerecover/FailedMessageRecoverApplicationTest.java
@@ -1,0 +1,14 @@
+package uk.ac.ebi.subs.messagerecover;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Profile;
+
+@SpringBootApplication
+@Profile("test")
+public class FailedMessageRecoverApplicationTest {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FailedMessageRecoverApplicationTest.class, args);
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/messagerecover/RecoveryIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/subs/messagerecover/RecoveryIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.ac.ebi.subs.messagerecover;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import uk.ac.ebi.subs.messagerecover.config.RecoverProperties;
 import uk.ac.ebi.subs.messagerecover.queuemanager.MessageToReplay;
 import uk.ac.ebi.subs.messagerecover.service.MessageRecoverService;
+import uk.ac.ebi.subs.messagerecover.util.RabbitMQAndQDBDependentTest;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,6 +41,7 @@ import static org.mockito.Mockito.doAnswer;
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FailedMessageRecoverApplicationTest.class)
 @ActiveProfiles("test")
+@Category(RabbitMQAndQDBDependentTest.class)
 public class RecoveryIntegrationTest {
 
     private static Logger logger = LoggerFactory.getLogger(RecoveryIntegrationTest.class);

--- a/src/test/java/uk/ac/ebi/subs/messagerecover/RecoveryIntegrationTest.java
+++ b/src/test/java/uk/ac/ebi/subs/messagerecover/RecoveryIntegrationTest.java
@@ -1,0 +1,193 @@
+package uk.ac.ebi.subs.messagerecover;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.ExchangeTypes;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.annotation.Exchange;
+import org.springframework.amqp.rabbit.annotation.Queue;
+import org.springframework.amqp.rabbit.annotation.QueueBinding;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitMessagingTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import uk.ac.ebi.subs.messagerecover.config.RecoverProperties;
+import uk.ac.ebi.subs.messagerecover.queuemanager.MessageToReplay;
+import uk.ac.ebi.subs.messagerecover.service.MessageRecoverService;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doAnswer;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = FailedMessageRecoverApplicationTest.class)
+@ActiveProfiles("test")
+public class RecoveryIntegrationTest {
+
+    private static Logger logger = LoggerFactory.getLogger(RecoveryIntegrationTest.class);
+
+    private static final String TEST_MESSAGE = "Added test message";
+    private static final int TEST_ID = 123;
+    private static final String DEFAULT_TEST_MESSAGE = "This is a test message ";
+    private static final int FAILED_MESSAGE_COUNT = 10;
+
+    private List<Message> replayedMessages = new ArrayList<>();
+    private List<String> testRoutingKeys = new ArrayList<>();
+
+    @Autowired
+    private RabbitMessagingTemplate rabbitMessagingTemplate;
+
+    @Autowired
+    private RecoverProperties recoverProperties;
+
+    @SpyBean
+    private MessageRecoverService recoverService;
+
+    private List<String> routingKeys;
+
+    @Before
+    public void setupBeforeClass() {
+        testRoutingKeys = Arrays.asList("test.sample.routingKey", "test.study.routingKey", "another.sample.routingKey");
+
+        rabbitMessagingTemplate.setMessageConverter(new MappingJackson2MessageConverter());
+    }
+
+    @Test
+    public void testMessageReplaying() throws InterruptedException {
+        publishMessages();
+        recoverService.transferMessagesToQDBDeadLetterQueue();
+        List<MessageToReplay> messagesToReplay = recoverService.readFilterMessagesFromQDBDaedLetterQueue();
+        System.out.println(messagesToReplay);
+
+        doAnswer(RecoveryIntegrationTest::answer).when(recoverService).fixFailedMessages(messagesToReplay);
+
+        recoverService.fixFailedMessages(messagesToReplay);
+        System.out.println(messagesToReplay);
+
+        recoverService.replayFailedMessages(messagesToReplay);
+
+        // Waiting for consuming the republished messages for check the result
+        Thread.sleep(3 * 1000);
+
+        checkReplayedMessagesCorrectness();
+    }
+
+    private void publishMessages() {
+        List<TestMessage> messages = generateMessages();
+        routingKeys = generateRoutingKeys();
+        for (int i = 0; i < FAILED_MESSAGE_COUNT; i++) {
+            rabbitMessagingTemplate.convertAndSend(
+                    "usi-1:dead-letter-exchange", routingKeys.get(i), messages.get(i));
+        }
+    }
+
+    private static Object answer(InvocationOnMock invocation) {
+        Object[] args = invocation.getArguments();
+        List<MessageToReplay> messagesToFix = (List<MessageToReplay>) args[0];
+        messagesToFix.forEach(messageToFix -> {
+            TestMessage testMessage = convertStringToObject(messageToFix.getBody());
+            testMessage.setTestMessage(TEST_MESSAGE);
+            testMessage.setTestId(TEST_ID);
+            convertObjectToString(messageToFix, testMessage);
+        });
+        return messagesToFix;
+    }
+
+    private List<TestMessage> generateMessages() {
+        List<TestMessage> testMessages = new ArrayList<>();
+        for (int i = 0; i < FAILED_MESSAGE_COUNT; i++) {
+            String message = DEFAULT_TEST_MESSAGE + i;
+            TestMessage testMessage = new TestMessage();
+            testMessage.setTestId(i);
+            testMessage.setMessage(message);
+            testMessages.add(testMessage);
+        }
+
+        return testMessages;
+    }
+
+    private List<String> generateRoutingKeys() {
+        List<String> routingKeys = new ArrayList<>();
+        int routingKeyTypeCount = testRoutingKeys.size();
+        for (int i = 0; i < FAILED_MESSAGE_COUNT; i++) {
+            routingKeys.add(testRoutingKeys.get(i % routingKeyTypeCount));
+        }
+
+        return routingKeys;
+    }
+
+    private void checkReplayedMessagesCorrectness() {
+        final String testRoutingKey = recoverProperties.getQdbProp().getMessageFilter().getRoutingKey();
+        int matchingRoutingKeyCount = new Long(routingKeys.stream()
+                .filter(routingKey -> routingKey.equals(testRoutingKey))
+                .count()).intValue();
+        assertThat(replayedMessages.size(), is(equalTo(matchingRoutingKeyCount)));
+
+        replayedMessages.forEach(replayedMessage -> {
+            TestMessage testMessage = convertStringToObject(new String(replayedMessage.getBody()));
+            assertNotNull(testMessage.getMessage());
+            assertThat(testMessage.getMessage(), is(containsString(DEFAULT_TEST_MESSAGE)));
+            assertThat(testMessage.getTestMessage(), is(equalTo(TEST_MESSAGE)));
+            assertThat(testMessage.getTestId(), is(equalTo(TEST_ID)));
+
+            assertThat(replayedMessage.getMessageProperties().getReceivedRoutingKey(), is(equalTo(testRoutingKey)));
+        });
+    }
+
+    private static TestMessage convertStringToObject(String message) {
+        ObjectMapper mapper = new ObjectMapper();
+        TestMessage testMessage;
+        try {
+            testMessage = mapper.readValue(message, TestMessage.class);
+        } catch (IOException e) {
+            return logAndThrowJSONConversionError(e);
+        }
+
+        return testMessage;
+    }
+
+    private static TestMessage convertObjectToString(MessageToReplay messageToFix, TestMessage testMessage) {
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            messageToFix.setBodyToReplay(mapper.writeValueAsString(testMessage));
+        } catch (IOException e) {
+            return logAndThrowJSONConversionError(e);
+        }
+
+        return testMessage;
+    }
+
+    private static TestMessage logAndThrowJSONConversionError(IOException e) {
+        String errorMessage =
+                String.format("Error happened converting the message to an Object: %s", e.getMessage());
+        logger.error(errorMessage);
+        throw new RuntimeException(errorMessage);
+    }
+
+
+    @RabbitListener(bindings = @QueueBinding(
+            value = @Queue(value = "${messageRecover.rabbitMQProp.replayQueueName}", durable = "true", autoDelete = "true"),
+            exchange = @Exchange(value = "${messageRecover.rabbitMQProp.exchangeName}", durable = "true", type = ExchangeTypes.TOPIC),
+            key = "${messageRecover.qdbProp.messageFilter.routingKey}")
+    )
+    private void consumeReplayedMessages(Message replayedMessage) {
+        replayedMessages.add(replayedMessage);
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/messagerecover/TestMessage.java
+++ b/src/test/java/uk/ac/ebi/subs/messagerecover/TestMessage.java
@@ -1,0 +1,28 @@
+package uk.ac.ebi.subs.messagerecover;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Data;
+
+import java.io.IOException;
+
+@Data
+public class TestMessage {
+
+    private int id;
+    private String message;
+    private int testId;
+    private String testMessage;
+
+    public TestMessage() {
+    }
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    public TestMessage(String jsonString) throws IOException {
+        TestMessage temp = objectMapper.readValue(jsonString, TestMessage.class);
+        this.id = temp.id;
+        this.message = temp.message;
+        this.testId = temp.testId;
+        this.testMessage = temp.testMessage;
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/messagerecover/util/RabbitMQAndQDBDependentTest.java
+++ b/src/test/java/uk/ac/ebi/subs/messagerecover/util/RabbitMQAndQDBDependentTest.java
@@ -1,0 +1,8 @@
+package uk.ac.ebi.subs.messagerecover.util;
+
+/**
+ * Marker interface for test that reply on RAbbitMQ and QDB presence.
+ */
+public interface RabbitMQAndQDBDependentTest {
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,32 @@
+spring:
+  main:
+    web-environment: false
+
+messageRecover:
+  inputBindingRemovalDelayInSec: 5
+  rabbitMQProp:
+    baseURL: amqp://rabbitmq-url
+    exchangeName: exchange-name
+    deadLetterExchangeName: dead-letter-exchange-name
+    deadLetterQueueName: dead-letter-queue-name
+    replayQueueName: test-replay-queue
+  qdbProp:
+    baseURL: http://qdb_url:9554
+    queue:
+      deadLetterQueueName: failed_messages_qdb_queue
+      basePath: /q
+      inputBasePath: /in
+      outputBasePath: /out
+      inputPath: /fromRabbit
+      outputPath: /toRabbit
+      maxSize: 1g
+      maxPayloadSize: 10m
+      contentType: "application/json; charset=utf-8"
+    messageFilter:
+      grep:
+      from:
+      to:
+      routingKey: test.sample.routingKey
+      fromId:
+
+


### PR DESCRIPTION
This integration test tries to simulate the whole message fixing workflow.

1. Creates some messages with different routing keys and publish them on the dead letter exchange
2. A QDB queue consumes them
3. The 'Recover app' filter the messages from the QDB queue with a specified routing key
4. The test mocks the 'message fixer' method of the "Recover app" and sets some additional properties on the messages
5. The test replays the changed messages to the original exchange (configurable) with their original routing key
6. Finally a consumer on the original queue checks if the republished messages are correct
